### PR TITLE
Planned features for 1.2:

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,36 @@
+=== 1.2 / 2015-06-08
+
+* 1 major enhancement
+
+  * Changed the preferred way of creating an error hierarchy from just
+    extending the error class with KineticCafe::ErrorDSL to calling
+    KineticCafe.create_hierarchy. Among other options this provides, the
+    automatic creation of helper methods and errors based on Rack::Utils status
+    codes can be controlled.
+
+* 5 minor enhancements
+
+  * Renamed KineticCafe#header_only? to KineticCafe#header? The old version is
+    still present but deprecated. Similarly, the option to
+    KineticCafe::ErrorDSL#define_error is now called +header+, but
+    +header_only+ also works.
+
+  * Added an option, +i18n_params+ to KineticCafe::ErrorDSL#define_error, used
+    to describe the I18n parameters that are expected to be provided to the
+    error for translations. This gets defined as a class method on the new
+    error. This should be passed as an array.
+
+  * Extracted most of the 'magic' functionality to KineticCafe::ErrorModule so
+    that useful hierarchies can be generated without inheriting directly from
+    KineticCafe::Error.
+
+  * Added a class method to the Rails controller concern to generate a new
+    rescue_from for a non-KineticCafe::Error-derived exception.
+
+  * Added a pair of rake tasks, kcerror:defined (shows defined errors) and
+    kcerror:translations (generates a sample translation key file).
+    Automatically inserted for Rails applications.
+
 === 1.1 / 2015-06-05
 
 * 7 minor enhancements

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -26,8 +26,11 @@ lib/kinetic_cafe/error.rb
 lib/kinetic_cafe/error/minitest.rb
 lib/kinetic_cafe/error_dsl.rb
 lib/kinetic_cafe/error_engine.rb
+lib/kinetic_cafe/error_module.rb
 lib/kinetic_cafe/error_rspec.rb
+lib/kinetic_cafe/error_tasks.rake
 lib/kinetic_cafe_error.rb
 test/test_helper.rb
 test/test_kinetic_cafe_error.rb
 test/test_kinetic_cafe_error_dsl.rb
+test/test_kinetic_cafe_error_hierarchy.rb

--- a/README.rdoc
+++ b/README.rdoc
@@ -9,24 +9,111 @@ continuous integration :: {<img src="https://travis-ci.org/KineticCafe/kinetic_c
 kinetic_cafe_error provides an API-smart error base class and a DSL for
 defining errors. Under Rails, it also provides a controller concern
 (KineticCafe::ErrorHandler) that has a useful implementation of +rescue_from+
-for KineticCafe::Error types.
+to handle KineticCafe::Error types.
+
+Exceptions in a hierarchy can be handled in a uniform manner, including getting
+an I18n translation message with parameters, standard status values, and
+meaningful JSON representations that can be used to establish a standard error
+representations across both clients and servers.
 
 == Synopsis
 
-  class MyErrorBase < KineticCafe::Error
-    extend KineticCafe::ErrorDSL
-  
-    not_found class: :user # => MyErrorBase::UserNotFound
-    unauthorized class: :user # => MyErrorBase::UserUnauthorized
-    forbidden class: :user # => MyErrorBase::UserForbidden
-    conflict class: :user# => MyErrorBase::UserConflict
+Define a hierarchy with KineticCafe::Error.hierarchy.
+
+  KineticCafe::Error.hierarchy class: :MyBaseError do
+    not_found class: :user # => MyBaseError::UserNotFound
+    unauthorized class: :user # => MyBaseError::UserUnauthorized
+    forbidden class: :user # => MyBaseError::UserForbidden
+    conflict class: :user# => MyBaseError::UserConflict
   end
+
+There are a few documented ways to define hierarchies. Examples for handling
+exceptions can be found in the provided Minitest assertions module and the
+RSpec matchers.
+
+=== Using with Rails
+
+When using KineticCafe::Error with Rails, KineticCafe::ErrorEngine is
+automatically injected, which enables the following functionality:
+
+* Two rake tasks:
+
+  * <tt>rake kcerror:defined</tt>, showing the errors defined in the known
+    hierarchy.
+
+  * <tt>rake kcerror:translations[output]</tt>, creating a template translation
+    file for all defined errors.
+
+* An error view, <tt>kinetic_cafe_error/page</tt>, in ERB, HAML, and Slim
+  formats. This also has a partial, <tt>kinetic_cafe_error/_table</tt>. This
+  allows KineticCafe::Error classes to be used in HTML contexts as well as JSON
+  contexts.
+
+* Access to the kinetic_cafe_error translation files for English and French,
+  used in logging and in the error view.
+
+* A controller concern, KineticCafe::ErrorHandler, that defines a +rescue_from+
+  handler for descendants of the KineticCafe::Error class, and a error handler
+  generator, #kinetic_cafe_error_handler_for, that sets a +rescue_from+ handler
+  for a KineticCafe::Error hierarchy that does not descend from
+  KineticCafe::Error itself.
+
+  #kinetic_cafe_error_handler distinguishes between HTML and JSON contexts.
+
+=== Using with Minitest
+
+KineticCafe::Error provides a number of assertions that can help testing that
+your code returns KineticCafe::Error hierarchies.
+
+* #assert_kc_error when used with the return value of +assert_raises+, verifies
+  that the captured exception is the expected exception, including parameters.
+  Also available as #must_be_kc_error.
+
+* assert_kc_error_json when used with a response body, verifies that the
+  response is the same as would be generated with the requested error class.
+  Also available as #must_be_kc_error_json.
+
+* assert_response_kc_error_html works with ActiveSupport::Test; it asserts that
+  the +kinetic_cafe_error/page+ template has been rendered and that the
+  expected class I18n key is part of the response body. Depends on
+  <tt>@response.body</tt> being part of the available test environment.
+
+* assert_response_kc_Error works with ActiveSupport::Test and checks
+  <tt>@request.format</tt> to determine whether to forward to
+  #assert_response_kc_error_html or #assert_kc_error_json.
+
+Get access to these with:
+
+  require 'kinetic_cafe/error/minitest'
+
+In your test setup code.
+
+=== Using with RSpec (Experimental)
+
+KineticCafe::Error provides four experimental matchers:
+
+* +be_json_for+ verifies that the JSON in the +actual+ string or body match the
+  +expected+ data structure.
+* +be_kc_error+ verifies that the error is the expected class and renders
+  properly with the same parameters.
+* +be_kc_error_json+ verifies that the JSON provided that the JSON output of the
+  +expected+ is generates the same JSON.
+* +be_kc_error_html+ verifies that the response renders the
+  +kinetic_cafe_error/page+ template.
 
 == Install
 
-Add kinetic_cafe_error to your gemfile:
+Add kinetic_cafe_error to your Gemfile:
 
-  gem 'kinetic_cafe_error', '~> 1.0'
+  gem 'kinetic_cafe_error', '~> 1.2'
+
+If not using Rails, install with RubyGems:
+
+  gem install kinetic_cafe_error
+
+And require where needed in your application:
+
+  require 'kinetic_cafe_error'
 
 :include: Contributing.rdoc
 :include: Licence.rdoc

--- a/Rakefile
+++ b/Rakefile
@@ -64,4 +64,6 @@ namespace :test do
   end
 end
 
+load 'lib/kinetic_cafe/error_tasks.rake'
+
 # vim: syntax=ruby

--- a/app/controllers/concerns/kinetic_cafe/error_handler.rb
+++ b/app/controllers/concerns/kinetic_cafe/error_handler.rb
@@ -7,7 +7,16 @@ module KineticCafe::ErrorHandler
   extend ActiveSupport::Concern
 
   included do
-    rescue_from KineticCafe::Error, with: :kinetic_cafe_error_handler
+    kinetic_cafe_error_handler_for KineticCafe::Error
+  end
+
+  module ClassMethods
+    # Create a new +rescue_from+ handler for the specified base class. Useful
+    # if the base is not a descendant of KineticCafe::Error, but includes
+    # KineticCafe::ErrorHandler.
+    def kinetic_cafe_error_handler_for(klass)
+      rescue_from klass, with: :kinetic_cafe_error_handler
+    end
   end
 
   # This method is called with +error+ when Rails catches a KineticCafe::Error
@@ -19,7 +28,9 @@ module KineticCafe::ErrorHandler
   # controllers for different behaviour.
   def kinetic_cafe_error_handler(error)
     Rails.logger.error(error.message)
-    Rails.logger.error("^-- caused by: #{error.cause.message}") if error.cause
+    if error.cause
+      Rails.logger.error(t('kinetic_cafe_error.cause', error.cause.message))
+    end
 
     respond_to do |format|
       format.html do

--- a/config/locales/kinetic_cafe_error.en-CA.yml
+++ b/config/locales/kinetic_cafe_error.en-CA.yml
@@ -12,3 +12,5 @@ en-CA:
       header:
         status: Status
         code: Code
+    cause: >-
+      ^-- caused by: %{message}

--- a/config/locales/kinetic_cafe_error.en-UK.yml
+++ b/config/locales/kinetic_cafe_error.en-UK.yml
@@ -12,3 +12,5 @@ en-UK:
       header:
         status: Status
         code: Code
+    cause: >-
+      ^-- caused by: %{message}

--- a/config/locales/kinetic_cafe_error.en-US.yml
+++ b/config/locales/kinetic_cafe_error.en-US.yml
@@ -12,3 +12,5 @@ en-US:
       header:
         status: Status
         code: Code
+    cause: >-
+      ^-- caused by: %{message}

--- a/config/locales/kinetic_cafe_error.en.yml
+++ b/config/locales/kinetic_cafe_error.en.yml
@@ -12,3 +12,5 @@ en:
       header:
         status: Status
         code: Code
+    cause: >-
+      ^-- caused by: %{message}

--- a/config/locales/kinetic_cafe_error.fr-CA.yml
+++ b/config/locales/kinetic_cafe_error.fr-CA.yml
@@ -12,3 +12,5 @@ fr-CA:
       header:
         status: Condition
         code: Code
+    cause: >-
+      ^-- causé par: %{message}

--- a/config/locales/kinetic_cafe_error.fr.yml
+++ b/config/locales/kinetic_cafe_error.fr.yml
@@ -12,3 +12,5 @@ fr:
       header:
         status: Condition
         code: Code
+    cause: >-
+      ^-- causé par: %{message}

--- a/kinetic_cafe_error.gemspec
+++ b/kinetic_cafe_error.gemspec
@@ -1,18 +1,18 @@
 # -*- encoding: utf-8 -*-
-# stub: kinetic_cafe_error 1.1 ruby lib
+# stub: kinetic_cafe_error 1.2 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "kinetic_cafe_error"
-  s.version = "1.1"
+  s.version = "1.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2015-06-05"
+  s.date = "2015-06-08"
   s.description = "kinetic_cafe_error provides an API-smart error base class and a DSL for\ndefining errors. Under Rails, it also provides a controller concern\n(KineticCafe::ErrorHandler) that has a useful implementation of +rescue_from+\nfor KineticCafe::Error types."
   s.email = ["aziegler@kineticcafe.com"]
   s.extra_rdoc_files = ["Contributing.rdoc", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Contributing.rdoc", "History.rdoc", "Licence.rdoc", "README.rdoc"]
-  s.files = [".autotest", ".gemtest", ".travis.yml", "Contributing.rdoc", "Gemfile", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Rakefile", "app/controllers/concerns/kinetic_cafe/error_handler.rb", "app/views/kinetic_cafe_error/_table.html.erb", "app/views/kinetic_cafe_error/_table.html.haml", "app/views/kinetic_cafe_error/_table.html.slim", "app/views/kinetic_cafe_error/page.html.erb", "app/views/kinetic_cafe_error/page.html.haml", "app/views/kinetic_cafe_error/page.html.slim", "config/i18n-tasks.yml.erb", "config/locales/kinetic_cafe_error.en-CA.yml", "config/locales/kinetic_cafe_error.en-UK.yml", "config/locales/kinetic_cafe_error.en-US.yml", "config/locales/kinetic_cafe_error.en.yml", "config/locales/kinetic_cafe_error.fr-CA.yml", "config/locales/kinetic_cafe_error.fr.yml", "lib/kinetic_cafe/error.rb", "lib/kinetic_cafe/error/minitest.rb", "lib/kinetic_cafe/error_dsl.rb", "lib/kinetic_cafe/error_engine.rb", "lib/kinetic_cafe/error_rspec.rb", "lib/kinetic_cafe_error.rb", "test/test_helper.rb", "test/test_kinetic_cafe_error.rb", "test/test_kinetic_cafe_error_dsl.rb"]
+  s.files = [".autotest", ".gemtest", ".travis.yml", "Contributing.rdoc", "Gemfile", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Rakefile", "app/controllers/concerns/kinetic_cafe/error_handler.rb", "app/views/kinetic_cafe_error/_table.html.erb", "app/views/kinetic_cafe_error/_table.html.haml", "app/views/kinetic_cafe_error/_table.html.slim", "app/views/kinetic_cafe_error/page.html.erb", "app/views/kinetic_cafe_error/page.html.haml", "app/views/kinetic_cafe_error/page.html.slim", "config/i18n-tasks.yml.erb", "config/locales/kinetic_cafe_error.en-CA.yml", "config/locales/kinetic_cafe_error.en-UK.yml", "config/locales/kinetic_cafe_error.en-US.yml", "config/locales/kinetic_cafe_error.en.yml", "config/locales/kinetic_cafe_error.fr-CA.yml", "config/locales/kinetic_cafe_error.fr.yml", "lib/kinetic_cafe/error.rb", "lib/kinetic_cafe/error/minitest.rb", "lib/kinetic_cafe/error_dsl.rb", "lib/kinetic_cafe/error_engine.rb", "lib/kinetic_cafe/error_module.rb", "lib/kinetic_cafe/error_rspec.rb", "lib/kinetic_cafe/error_tasks.rake", "lib/kinetic_cafe_error.rb", "test/test_helper.rb", "test/test_kinetic_cafe_error.rb", "test/test_kinetic_cafe_error_dsl.rb", "test/test_kinetic_cafe_error_hierarchy.rb"]
   s.homepage = "https://github.com/KineticCafe/kinetic_cafe_error/"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.rdoc"]

--- a/lib/kinetic_cafe/error_engine.rb
+++ b/lib/kinetic_cafe/error_engine.rb
@@ -2,5 +2,8 @@ module KineticCafe
   # If Rails is defined, KineticCafe::ErrorEngine will be loaded automatically,
   # providing access to the KineticCafe::ErrorHandler.
   class ErrorEngine < ::Rails::Engine
+    rake_tasks do
+      load "#{__dir__}/error_tasks.rake"
+    end
   end
 end

--- a/lib/kinetic_cafe/error_module.rb
+++ b/lib/kinetic_cafe/error_module.rb
@@ -1,0 +1,192 @@
+module KineticCafe # :nodoc:
+  # The core functionality provided by a KineticCafe::Error, extracted to a
+  # module to ensure that exceptions that are made hosts of error hierarchies
+  # have expected functionality.
+  module ErrorModule
+    # The HTTP status to be returned. If not provided in the constructor, uses
+    # #default_status.
+    attr_reader :status
+    # Extra data relevant to recipients of the exception, provided on
+    # construction.
+    attr_reader :extra
+    # The exception that caused this exception; provided on construction.
+    attr_reader :cause
+
+    # Create a new error with the given parameters.
+    #
+    # === Options
+    #
+    # +message+:: A message override. This may be provided either as the first
+    #             parameter to the constructor or may be provided as an option.
+    #             A value provided as the first parameter overrides any other
+    #             value.
+    # +status+::  An override to the HTTP status code to be returned by this
+    #             error by default.
+    # +i18n_params+:: The parameters to be sent to I18n.translate with the
+    #                 #i18n_key.
+    # +cause+:: The exception that caused this error. Used to wrap an earlier
+    #           exception.
+    # +extra+:: Extra data to be returned in the API representation of this
+    #           exception.
+    # +query+:: A hash of parameters added to +i18n_params+, typically from
+    #           Rails controller +params+ or model +where+ query. This hash
+    #           will be converted into a string value similar to
+    #           ActiveSupport#to_query.
+    #
+    # Any unmatched options will be added to +i18n_params+. Because of this,
+    # the following constructors are identical:
+    #
+    #     KineticCafe::Error.new(i18n_params: { x: 1 })
+    #     KineticCafe::Error.new(x: 1)
+    #
+    # :call-seq:
+    #    new(message, options = {})
+    #    new(options)
+    def initialize(*args)
+      options = args.last.kind_of?(Hash) ? args.pop.dup : {}
+      @message = args.shift
+      @message = options.delete(:message) if @message.nil? || @message.empty?
+      options.delete(:message)
+
+      @message && @message.freeze
+
+      @status      = options.delete(:status) || default_status
+      @i18n_params = options.delete(:i18n_params) || {}
+      @extra       = options.delete(:extra)
+      @cause       = options.delete(:cause)
+
+      @i18n_params.update(cause: cause.message) if cause
+
+      query = options.delete(:query)
+      @i18n_params.merge!(query: stringify(query)) if query
+      @i18n_params.merge!(options)
+      @i18n_params.freeze
+    end
+
+    # The message associated with this exception. If not provided, defaults to
+    # #i18n_message.
+    def message
+      @message || i18n_message
+    end
+
+    # The name of the error class.
+    def name
+      @name ||= KineticCafe::ErrorDSL.namify(self.class.name)
+    end
+
+    # The key used for I18n translation.
+    def i18n_key
+      @i18n_key ||= if self.class.respond_to? :i18n_key
+                      self.class.i18n_key
+                    else
+                      [
+                        i18n_key_base, (name)
+                      ].join('.').freeze
+                    end
+    end
+    alias_method :code, :i18n_key
+
+    # Indicates that this error should *not* have its details rendered to the
+    # user, but should use the +head+ method.
+    def header?
+      false
+    end
+    alias_method :header_only?, :header?
+
+    # Indicates that this error should be rendered to the client, but clients
+    # are advised *not* to display the message to the user.
+    def internal?
+      false
+    end
+
+    # The I18n translation of the message. If I18n.translate is defined,
+    # returns #i18n_key and the I18n parameters.
+    def i18n_message
+      @i18n_message ||= if defined?(I18n.translate)
+                          I18n.translate(i18n_key, @i18n_params).freeze
+                        else
+                          [ i18n_key, @i18n_params ].freeze
+                        end
+    end
+
+    # The details of this error as a hash. Values that are empty or nil are
+    # omitted.
+    def api_error(*)
+      {
+        message:      @message,
+        status:       status,
+        name:         name,
+        internal:     internal?,
+        i18n_message: i18n_message,
+        i18n_key:     i18n_key,
+        i18n_params:  @i18n_params,
+        cause:        cause && cause.message,
+        extra:        extra
+      }.delete_if { |_, v| v.nil? || (v.respond_to?(:empty?) && v.empty?) }
+    end
+    alias_method :as_json, :api_error
+
+    # An error result that can be passed as a response body.
+    def error_result
+      { error: api_error, message: message }
+    end
+
+    # A hash that can be passed to the Rails +render+ method with +status+ of
+    # #status and +layout+ false. The +json+ field is rendered as a hash of
+    # +error+ (calling #api_error) and +message+ (calling #message).
+    def json_result
+      { status: status, json: error_result, layout: false }
+    end
+    alias_method :render_json_for_rails, :json_result
+
+    # Nice debugging version of a KineticCafe::Error
+    def inspect
+      "#<#{self.class}: name=#{name} status=#{status} " \
+        "message=#{message.inspect} i18n_key=#{i18n_key} " \
+        "i18n_params=#{@i18n_params.inspect} extra=#{extra.inspect} " \
+        "cause=#{cause}>"
+    end
+
+    class << self
+      ##
+      # The base for I18n key resolution. Defaults to 'kcerrors'.
+      #
+      # :method: i18n_key_base
+
+      ##
+      # The names of the expected parameters for this error. Defaults to [].
+      #
+      # :method: i18n_params
+
+      ##
+      # The i18n_key for the parameter. Defaults to the combination of
+      # i18n_key_base and the namified version of the class (see
+      # KineticCafe::ErrorDSL.namify).
+      #
+      # :method: i18n_key
+
+      ##
+      def included(mod)
+        unless mod.respond_to?(:i18n_key_base)
+          mod.send :define_singleton_method, :i18n_key_base do
+            'kcerrors'.freeze
+          end
+        end
+
+        unless mod.respond_to?(:i18n_params)
+          mod.send :define_singleton_method, :i18n_params do
+            [].freeze
+          end
+        end
+
+        unless mod.respond_to?(:i18n_key)
+          mod.send :define_singleton_method, :i18n_key do
+            @i18n_key ||= [
+              i18n_key_base, KineticCafe::ErrorDSL.namify(name)
+            ].join('.').freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kinetic_cafe/error_rspec.rb
+++ b/lib/kinetic_cafe/error_rspec.rb
@@ -12,6 +12,14 @@ module KineticCafe
   # +be_json_for+:: Verifies that the expected value is a JSON representation
   #                 of the actual value. If the actual value responds to
   #                 #body, the actual value is replaced with +actual.body+.
+  #
+  # +be_kc_error+:: Verifies that the expected value is a KineticCafe::Error.
+  #
+  # +be_kc_error_json+:: Verifies that the JSON value matches the output of
+  #                      KineticCafe::Error.
+  #
+  # +be_kc_error_html+:: Verifies that the rendered HTML matches the output of
+  #                      KineticCafe::Error.
   module ErrorRspec
     extend ::Rspec::Matchers::DSL
 
@@ -30,6 +38,7 @@ module KineticCafe
 
     matcher :be_kc_error do |expected, params = {}|
       match do |actual|
+        expect(actual).to be_kind_of(KineticCafe::ErrorModule)
         expect(actual).to be_kind_of(expected)
         expect(actual).to eq(expected.new(params))
       end
@@ -44,6 +53,14 @@ module KineticCafe
       end
 
       diffable
+    end
+
+    matcher :be_kc_error_html do |expected, params = {}|
+      match do |actual|
+        expect(actual).to render_template('kinetic_cafe_error/page')
+        expect(actual).to render_template('kinetic_cafe_error/_table')
+        expect(actual).to include(expected.i18n_key)
+      end
     end
   end
 end

--- a/lib/kinetic_cafe/error_tasks.rake
+++ b/lib/kinetic_cafe/error_tasks.rake
@@ -1,0 +1,59 @@
+namespace :kcerror do
+  desc 'Show defined errors.'
+  task defined: 'kcerror:find' do
+    display = ->(root, prefix = '') {
+      puts "#{prefix}- #{root}"
+
+      if @descendants[root]
+        sorted = @descendants[root].sort_by(&:to_s)
+        sorted.each do |child|
+          s = (child == sorted.last) ? '`' : '|'
+          display.(child, "#{prefix.tr('|`', ' ')}  #{s}")
+        end
+      end
+    }
+
+    @descendants[StandardError].sort_by(&:to_s).each { |d| display.(d) }
+  end
+
+  desc 'Generate a sample translation key file.'
+  task :translations, [ :output ] => 'kcerror:find' do |_, args|
+    translations = {}
+    traverse = ->(root) {
+      translation = (translations[root.i18n_key_base] ||= {})
+      name = KineticCafe::ErrorDSL.namify(root)
+
+      params = root.i18n_params.map { |param| "%{#{param}}" }.join(' ')
+
+      if params.empty?
+        translation[name] = %Q(Translation for #{name} with no params.)
+      else
+        translation[name] = %Q(Translation for #{name} with #{params}.)
+      end
+
+      if @descendants[root]
+        @descendants[root].sort_by(&:to_s).each { |child| traverse.(child) }
+      end
+    }
+
+    @descendants[StandardError].sort_by(&:to_s).each { |d| traverse.(d) }
+
+    require 'yaml'
+    translations = YAML.dump({ 'en' => translations })
+
+    if args.output
+      File.open(args.output, 'w') { |f| f.write translations }
+    else
+      puts translations
+    end
+  end
+
+  task :find do
+    @descendants = {}
+    ObjectSpace.each_object(Class) do |k|
+      next unless k.singleton_class < KineticCafe::ErrorDSL
+
+      (@descendants[k.superclass] ||= []) << k
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,9 @@
 
 gem 'minitest'
 require 'minitest/autorun'
-require 'minitest/stub_const'
+require 'minitest/focus'
 require 'minitest/moar'
+require 'minitest/stub_const'
 require 'rack/test'
 require 'kinetic_cafe_error'
 

--- a/test/test_kinetic_cafe_error.rb
+++ b/test/test_kinetic_cafe_error.rb
@@ -66,16 +66,35 @@ describe KineticCafe::Error do
     end
 
     it 'encodes the :query parameter specially for I18n parameters' do
-      exception = KineticCafe::Error.new(query: { a: 1, b: %w(x y z )})
+      query = {
+        a: 1,
+        b: %w(x y z),
+        c: [ d: 1, e: 2 ],
+        f: []
+      }
+
+      exception = KineticCafe::Error.new(query: query)
       Object.stub_remove_const(:I18n) do
         assert_equal(
           [
             'kcerrors.error',
-            { query: "a: 1; b[]: x, b[]: y, b[]: z" }
+            { query: "a: 1; b[]: x, b[]: y, b[]: z; c[][d]: 1; c[][e]: 2; f[]: []" }
           ],
           exception.i18n_message
         )
       end
+    end
+
+    it 'is not #header? by default' do
+      refute exception.header?
+    end
+
+    it 'is not #internal? by default' do
+      refute exception.internal?
+    end
+
+    it 'has no I18n parameters by default' do
+      assert_empty KineticCafe::Error.i18n_params
     end
   end
 end

--- a/test/test_kinetic_cafe_error_hierarchy.rb
+++ b/test/test_kinetic_cafe_error_hierarchy.rb
@@ -1,0 +1,147 @@
+require 'test_helper'
+require 'rack/test'
+
+describe KineticCafe::Error, '.hierarchy' do
+  describe '(class: :My)' do
+    def my(&block)
+      KineticCafe::Error.hierarchy(class: :My, &block)
+    end
+
+    it 'creates a new object' do
+      my
+      assert Object.const_defined?(:My)
+    end
+
+    it 'descends from KineticCafe::Error' do
+      my
+      assert My < KineticCafe::Error
+    end
+
+    it 'has been extended with KineticCafe::ErrorDSL' do
+      my
+      assert My.singleton_class < KineticCafe::ErrorDSL
+    end
+
+    it 'yields self if a block with an argument is given' do
+      my do |err|
+        assert_same My, err
+      end
+    end
+
+    it 'runs instance_exec against self if a no-argument block is given' do
+      assert my { My == self }
+    end
+
+    it 'cannot be extended a second time' do
+      my
+      ex = assert_raises do
+        KineticCafe::Error.hierarchy(class: :My)
+      end
+      assert_match(/is already a root hierarchy/, ex.message)
+    end
+
+    after do
+      Object.send(:remove_const, :My) if Object.const_defined?(:My)
+    end
+  end
+
+  describe '(class: :My, namespace: Foo)' do
+    before do
+      Foo = Module.new
+      KineticCafe::Error.hierarchy(class: :My, namespace: Foo)
+    end
+
+    it 'creates a new object' do
+      assert Foo.const_defined?(:My)
+    end
+
+    it 'descends from KineticCafe::Error' do
+      assert Foo::My < KineticCafe::Error
+    end
+
+    it 'has been extended with KineticCafe::ErrorDSL' do
+      assert Foo::My.singleton_class < KineticCafe::ErrorDSL
+    end
+
+    it 'cannot be extended a second time' do
+      ex = assert_raises do
+        KineticCafe::Error.hierarchy(class: :My, namespace: Foo)
+      end
+      assert_match(/is already a root hierarchy/, ex.message)
+    end
+
+    after do
+      Foo.send(:remove_const, :My) if Foo.const_defined?(:My)
+      Object.send(:remove_const, :Foo) if Object.const_defined?(:Foo)
+    end
+  end
+
+  describe '(class: My)' do
+    describe 'when My is a StandardError' do
+      before do
+        My = Class.new(StandardError)
+        KineticCafe::Error.hierarchy(class: My)
+      end
+
+      it 'has been extended with KineticCafe::ErrorDSL' do
+        assert My.singleton_class < KineticCafe::ErrorDSL
+      end
+
+      it 'has KineticCafe::ErrorModule included' do
+        assert My < KineticCafe::ErrorModule
+      end
+
+      it 'cannot be extended a second time' do
+        ex = assert_raises do
+          KineticCafe::Error.hierarchy(class: :My)
+        end
+        assert_match(/is already a root hierarchy/, ex.message)
+      end
+
+      after do
+        Object.send(:remove_const, :My) if Object.const_defined?(:My)
+      end
+    end
+
+    it 'fails if My is not an Exception' do
+      ex = assert_raises do
+        KineticCafe::Error.hierarchy(class: Class.new)
+      end
+      assert_match(/cannot root.*StandardError/, ex.message)
+    end
+
+    it 'fails if My is not a StandardError' do
+      assert_raises do
+        KineticCafe::Error.hierarchy(class: Class.new(Exception))
+      end
+    end
+  end
+
+  describe '(class: :My, rack_status: option)' do
+    def my(option, &block)
+      KineticCafe::Error.hierarchy(class: :My, rack_status: option, &block)
+    end
+
+    it 'disables method and object creation when rack_status: false' do
+      my(false)
+      refute My.const_defined?(:NotFound)
+      refute My.respond_to?(:not_found)
+    end
+
+    it 'disables method creation when rack_status: { methods: false }' do
+      my(methods: false)
+      assert My.const_defined?(:NotFound)
+      refute My.respond_to?(:not_found)
+    end
+
+    it 'disables object creation when rack_status: { errors: false }' do
+      my(errors: false)
+      refute My.const_defined?(:NotFound)
+      assert My.respond_to?(:not_found)
+    end
+
+    after do
+      Object.send(:remove_const, :My) if Object.const_defined?(:My)
+    end
+  end
+end


### PR DESCRIPTION
- 1 major enhancement
  - Changed the preferred way of creating an error hierarchy from just
    extending the error class with KineticCafe::ErrorDSL to calling
    KineticCafe.create_hierarchy. Among other options this provides, the
    automatic creation of helper methods and errors based on Rack::Utils status
    codes can be controlled.
- 4 minor enhancements
  - Renamed KineticCafe#header_only? to KineticCafe#header? The old version is
    still present but deprecated. Similarly, the option to
    KineticCafe::ErrorDSL#define_error is now called +header+, but
    +header_only+ also works.
  - Added an option, +i18n_params+ to KineticCafe::ErrorDSL#define_error, used
    to describe the I18n parameters that are expected to be provided to the
    error for translations. This gets defined as a class method on the new
    error. This should be passed as an array.
  - Extracted most of the 'magic' functionality to KineticCafe::ErrorModule so
    that useful hierarchies can be generated without inheriting directly from
    KineticCafe::Error.
  - Added a class method to the Rails controller concern to generate a new
    rescue_from for a non-KineticCafe::Error-derived exception.
