### PR TITLE
Handle error causes correctly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - jruby-1.7
-  - jruby-9.0.0.0.pre2
-  - jruby-19mode
+  - jruby-9.0.0.0
   - jruby-head
   - ruby-head
   - rbx-2
@@ -15,7 +14,6 @@ matrix:
   allow_failures:
     - rvm: rbx-2
     - rvm: jruby-head
-    - rvm: jruby-9.0.0.0.pre2
     - rvm: ruby-head
 gemfile:
   - Gemfile

--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,22 @@
+=== 1.5 / 2015-07-28
+
+* 2 bug fixes:
+
+  * Handle error causes correctly for Ruby 2.1 or later, where <tt>raise
+    Exception, cause: RuntimeError.new</tt> does not pass the +cause+ the
+    exception constructor, but it still sets the cause correctly on the
+    exception. These changes make this correct for both +raise+ construction
+    and normal construction.
+
+  * The RSpec helpers did not work because they spelled the class +Rspec+, not
+    +RSpec+. This has been fixed.
+
+* 2 development changes:
+
+  * Fixed some test typos.
+
+  * Add i18n-tasks for CSV exports.
+
 === 1.4.1 / 2015-07-08
 
 * 1 bug fix

--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,8 @@ spec = Hoe.spec 'kinetic_cafe_error' do
   extra_dev_deps << ['minitest-stub-const', '~> 0.4']
   extra_dev_deps << ['rack-test', '~> 0.6']
   extra_dev_deps << ['rake', '~> 10.0']
+  extra_dev_deps << ['i18n-tasks', '~> 0.8']
+  extra_dev_deps << ['i18n-tasks-csv', '~> 1.0']
   extra_dev_deps << ['rubocop', '~> 0.32']
   extra_dev_deps << ['simplecov', '~> 0.7']
   extra_dev_deps << ['coveralls', '~> 0.8']

--- a/app/controllers/concerns/kinetic_cafe/error_handler.rb
+++ b/app/controllers/concerns/kinetic_cafe/error_handler.rb
@@ -28,7 +28,7 @@ module KineticCafe::ErrorHandler
     def kinetic_cafe_error_handler_log_locale(locale = nil)
       self.__kinetic_cafe_error_handler_log_locale = locale if locale
       self.__kinetic_cafe_error_handler_log_locale ||= I18n.default_locale
-      self.__kinetic_cafe_error_handler_log_locale
+      __kinetic_cafe_error_handler_log_locale
     end
   end
 

--- a/config/i18n-tasks.yml.erb
+++ b/config/i18n-tasks.yml.erb
@@ -109,3 +109,11 @@ ignore_eq_base:
 ## Ignore these keys completely:
 # ignore:
 #  - kaminari.*
+
+<% require 'i18n-tasks-csv' %>
+
+csv:
+  export:
+    - tmp/i18n-export/kinetic_cafe_error.csv
+  import:
+    - tmp/i18n-export/kinetic_cafe_error.csv

--- a/kinetic_cafe_error.gemspec
+++ b/kinetic_cafe_error.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: kinetic_cafe_error 1.4.1 ruby lib
+# stub: kinetic_cafe_error 1.5 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "kinetic_cafe_error"
-  s.version = "1.4.1"
+  s.version = "1.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2015-07-08"
+  s.date = "2015-07-28"
   s.description = "kinetic_cafe_error provides an API-smart error base class and a DSL for\ndefining errors. Under Rails, it also provides a controller concern\n(KineticCafe::ErrorHandler) that has a useful implementation of +rescue_from+\nto handle KineticCafe::Error types.\n\nExceptions in a hierarchy can be handled in a uniform manner, including getting\nan I18n translation message with parameters, standard status values, and\nmeaningful JSON representations that can be used to establish a standard error\nrepresentations across both clients and servers."
   s.email = ["aziegler@kineticcafe.com"]
   s.extra_rdoc_files = ["Contributing.rdoc", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Contributing.rdoc", "History.rdoc", "Licence.rdoc", "README.rdoc"]
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.rdoc"]
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
-  s.rubygems_version = "2.4.5"
+  s.rubygems_version = "2.4.8"
   s.summary = "kinetic_cafe_error provides an API-smart error base class and a DSL for defining errors"
 
   if s.respond_to? :specification_version then
@@ -38,6 +38,8 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<minitest-stub-const>, ["~> 0.4"])
       s.add_development_dependency(%q<rack-test>, ["~> 0.6"])
       s.add_development_dependency(%q<rake>, ["~> 10.0"])
+      s.add_development_dependency(%q<i18n-tasks>, ["~> 0.8"])
+      s.add_development_dependency(%q<i18n-tasks-csv>, ["~> 1.0"])
       s.add_development_dependency(%q<rubocop>, ["~> 0.32"])
       s.add_development_dependency(%q<simplecov>, ["~> 0.7"])
       s.add_development_dependency(%q<coveralls>, ["~> 0.8"])
@@ -57,6 +59,8 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<minitest-stub-const>, ["~> 0.4"])
       s.add_dependency(%q<rack-test>, ["~> 0.6"])
       s.add_dependency(%q<rake>, ["~> 10.0"])
+      s.add_dependency(%q<i18n-tasks>, ["~> 0.8"])
+      s.add_dependency(%q<i18n-tasks-csv>, ["~> 1.0"])
       s.add_dependency(%q<rubocop>, ["~> 0.32"])
       s.add_dependency(%q<simplecov>, ["~> 0.7"])
       s.add_dependency(%q<coveralls>, ["~> 0.8"])
@@ -77,6 +81,8 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<minitest-stub-const>, ["~> 0.4"])
     s.add_dependency(%q<rack-test>, ["~> 0.6"])
     s.add_dependency(%q<rake>, ["~> 10.0"])
+    s.add_dependency(%q<i18n-tasks>, ["~> 0.8"])
+    s.add_dependency(%q<i18n-tasks-csv>, ["~> 1.0"])
     s.add_dependency(%q<rubocop>, ["~> 0.32"])
     s.add_dependency(%q<simplecov>, ["~> 0.7"])
     s.add_dependency(%q<coveralls>, ["~> 0.8"])

--- a/lib/kinetic_cafe/error.rb
+++ b/lib/kinetic_cafe/error.rb
@@ -25,7 +25,7 @@ module KineticCafe # :nodoc:
   # rescue clause and handled there, as is shown in the included
   # KineticCafe::ErrorHandler controller concern for Rails.
   class Error < ::StandardError
-    VERSION = '1.4.1' # :nodoc:
+    VERSION = '1.5' # :nodoc:
 
     # Get the KineticCafe::Error functionality.
     include KineticCafe::ErrorModule

--- a/lib/kinetic_cafe/error_rspec.rb
+++ b/lib/kinetic_cafe/error_rspec.rb
@@ -5,8 +5,8 @@ module KineticCafe
   # these with:
   #
   #   require 'kinetic_cafe/error_rspec'
-  #   Rspec.configure do |c|
-  #     c.include KineticCafe::ErrorRspec
+  #   RSpec.configure do |c|
+  #     c.include KineticCafe::ErrorRSpec
   #   end
   #
   # +be_json_for+:: Verifies that the expected value is a JSON representation
@@ -20,8 +20,8 @@ module KineticCafe
   #
   # +be_kc_error_html+:: Verifies that the rendered HTML matches the output of
   #                      KineticCafe::Error.
-  module ErrorRspec
-    extend ::Rspec::Matchers::DSL
+  module ErrorRSpec
+    extend ::RSpec::Matchers::DSL
 
     matcher :be_json_for do |expected|
       match do |actual|

--- a/test/test_kinetic_cafe_error.rb
+++ b/test/test_kinetic_cafe_error.rb
@@ -153,7 +153,8 @@ describe KineticCafe::Error do
           fail 'causing'
         rescue => ex
           @causing_exception = ex
-          raise KineticCafe::Error, message: 'wrapping'
+          raise KineticCafe::Error, cause: @causing_exception,
+            message: 'wrapping'
         end
       rescue => ex
         @wrapping_exception = ex

--- a/test/test_kinetic_cafe_error.rb
+++ b/test/test_kinetic_cafe_error.rb
@@ -13,7 +13,7 @@ describe KineticCafe::Error do
       end
     end
 
-    describe '#messsage and #i18n_message' do
+    describe '#message and #i18n_message' do
       it 'returns key/params if I18n.translate is not defined' do
         Object.stub_remove_const(:I18n) do
           assert_equal [ 'kcerrors.error', {} ], exception.i18n_message

--- a/test/test_kinetic_cafe_error.rb
+++ b/test/test_kinetic_cafe_error.rb
@@ -145,4 +145,32 @@ describe KineticCafe::Error do
       assert_empty KineticCafe::Error.i18n_params
     end
   end
+
+  describe 'handles causing exceptions' do
+    before do
+      begin
+        begin
+          fail 'causing'
+        rescue => ex
+          @causing_exception = ex
+          raise KineticCafe::Error, message: 'wrapping'
+        end
+      rescue => ex
+        @wrapping_exception = ex
+      end
+    end
+
+    it 'captures the causting exception' do
+      refute_nil @wrapping_exception.cause, 'No exception captured'
+      assert_equal @causing_exception, @wrapping_exception.cause
+    end
+
+    it 'puts the cause message in i18n_params when the cause is requested' do
+      refute_nil @wrapping_exception.cause, 'No exception captured'
+      assert_equal(
+        { cause: 'causing' },
+        @wrapping_exception.instance_variable_get(:@i18n_params)
+      )
+    end
+  end
 end


### PR DESCRIPTION
- In Ruby 2.1, `raise Exception, cause: RuntimeError.new` does not pass the `cause`
  to the exception constructor, but it still sets the cause correctly on the
  exception. These changes make this correct for both `raise` construction and
  normal construction.
- Fix several small typos.
- Add i18n-tasks for CSV exports.
