### PR TITLE
Clean up test verification for captured causes.

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,4 +1,18 @@
-=== 1.5 / 2015-07-28
+=== 1.6 / 2015-07-30
+
+* 2 minor enhancements:
+
+  * Improve the Minitest and RSpec test helpers so that they ignore the error
+    +cause+ if it is not included as part of the assertion. The specification
+    of the +cause+ is recommended if you have specific values you want to
+    compare.
+
+  * Improve +kinetic_cafe_error_handler+ so that if it is called with an error
+    class instead of an instance of an error, it will construct the error
+    instance with the provided parameters. This makes custom +rescue_from+
+    constructions cleaner.
+
+=== 1.5 / 2015-07-29
 
 * 2 bug fixes:
 

--- a/app/controllers/concerns/kinetic_cafe/error_handler.rb
+++ b/app/controllers/concerns/kinetic_cafe/error_handler.rb
@@ -40,7 +40,28 @@ module KineticCafe::ErrorHandler
   # HTML is rendered with #kinetic_cafe_error_render_html. JSON is rendered
   # with #kinetic_cafe_error_render_json. Either of these can be overridden in
   # controllers for different behaviour.
-  def kinetic_cafe_error_handler(error)
+  #
+  # As an option, +kinetic_cafe_error_handler+ can also be used in a
+  # +rescue_from+ block with an error class and parameters, and it will
+  # construct the error for handling. The following example assumes that there
+  # is an error called ObjectNotFound.
+  #
+  #   rescue_from ActiveRecord::NotFound do |error|
+  #     kinetic_cafe_error_handler KineticCafe::Error::ObjectNotFound,
+  #       cause: error
+  #   end
+  #
+  # This would be the same as:
+  #
+  #   rescue_from ActiveRecord::NotFound do |error|
+  #     kinetic_cafe_error_handler KineticCafe::Error::ObjectNotFound.new(
+  #       cause: error
+  #     )
+  #   end
+  def kinetic_cafe_error_handler(error, error_params = {})
+    # If the error provided is actually an error class, make an error instance.
+    error.kind_of?(KineticCafe::ErrorDSL) && error = error.new(error_params)
+
     kinetic_cafe_error_log_error(error)
 
     respond_to do |format|

--- a/kinetic_cafe_error.gemspec
+++ b/kinetic_cafe_error.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: kinetic_cafe_error 1.5 ruby lib
+# stub: kinetic_cafe_error 1.6 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "kinetic_cafe_error"
-  s.version = "1.5"
+  s.version = "1.6"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2015-07-28"
+  s.date = "2015-07-29"
   s.description = "kinetic_cafe_error provides an API-smart error base class and a DSL for\ndefining errors. Under Rails, it also provides a controller concern\n(KineticCafe::ErrorHandler) that has a useful implementation of +rescue_from+\nto handle KineticCafe::Error types.\n\nExceptions in a hierarchy can be handled in a uniform manner, including getting\nan I18n translation message with parameters, standard status values, and\nmeaningful JSON representations that can be used to establish a standard error\nrepresentations across both clients and servers."
   s.email = ["aziegler@kineticcafe.com"]
   s.extra_rdoc_files = ["Contributing.rdoc", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Contributing.rdoc", "History.rdoc", "Licence.rdoc", "README.rdoc"]

--- a/lib/kinetic_cafe/error.rb
+++ b/lib/kinetic_cafe/error.rb
@@ -25,7 +25,7 @@ module KineticCafe # :nodoc:
   # rescue clause and handled there, as is shown in the included
   # KineticCafe::ErrorHandler controller concern for Rails.
   class Error < ::StandardError
-    VERSION = '1.5' # :nodoc:
+    VERSION = '1.6' # :nodoc:
 
     # Get the KineticCafe::Error functionality.
     include KineticCafe::ErrorModule

--- a/lib/kinetic_cafe/error_module.rb
+++ b/lib/kinetic_cafe/error_module.rb
@@ -73,6 +73,7 @@ module KineticCafe # :nodoc:
       @extra       = options.delete(:extra)
 
       @initialized_cause = false
+      @cause = nil
       initialize_cause(options.delete(:cause)) if options.key?(:cause)
 
       query = options.delete(:query)

--- a/lib/kinetic_cafe/error_rspec.rb
+++ b/lib/kinetic_cafe/error_rspec.rb
@@ -40,6 +40,16 @@ module KineticCafe
       match do |actual|
         expect(actual).to be_kind_of(KineticCafe::ErrorModule)
         expect(actual).to be_kind_of(expected)
+
+        unless params.key?(:cause)
+          actual = actual.dup
+          actual.instance_variable_set(:@cause, nil)
+          actual.instance_variable_set(:@initialized_cause, true)
+          actual.instance_variable_get(:@i18n_params).tap do |params|
+            params.delete(:cause)
+          end
+        end
+
         expect(actual).to eq(expected.new(params))
       end
 
@@ -48,6 +58,17 @@ module KineticCafe
 
     matcher :be_kc_error_json do |expected, params = {}|
       match do |actual|
+        unless params.key?(:cause)
+          actual['error'].tap do |error|
+            error.delete('cause')
+            if error['i18n_params']
+              error['i18n_params'].delete('cause')
+              error.delete('i18n_params') if error['i18n_params'].empty?
+            end
+          end
+          actual
+        end
+
         expect(actual).to \
           be_json_for(JSON.parse(expected.new(params).error_result.to_json))
       end

--- a/test/test_kinetic_cafe_error.rb
+++ b/test/test_kinetic_cafe_error.rb
@@ -161,7 +161,7 @@ describe KineticCafe::Error do
       end
     end
 
-    it 'captures the causting exception' do
+    it 'captures the causing exception' do
       refute_nil @wrapping_exception.cause, 'No exception captured'
       assert_equal @causing_exception, @wrapping_exception.cause
     end


### PR DESCRIPTION
- Also make it cleaner to call `kinetic_cafe_error_handler` with an error class
  in a Rails `rescue_from` context.
