### PR TITLE
Release 1.7, Bugfix & Features

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,5 +1,10 @@
 === 1.7 / 2015-08-05
 
+* 1 minor enhancement:
+
+  * Add a +params+ parameter to the <tt>kcerror:defined</tt> task that
+    will show the parameter names the exception expects.
+
 * 1 bug fix:
 
   * RubyMine does not fully initialize the project when running RSpec, meaning

--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,11 @@
+=== 1.7 / 2015-08-05
+
+* 1 bug fix:
+
+  * RubyMine does not fully initialize the project when running RSpec, meaning
+    that while Rake is defined, Rake::DSL is not. As such, we need to prevent
+    the Rake task from loading unless Rake::DSL is present.
+
 === 1.6 / 2015-07-30
 
 * 2 minor enhancements:

--- a/README.rdoc
+++ b/README.rdoc
@@ -110,7 +110,7 @@ KineticCafe::Error provides four experimental matchers:
 
 Add kinetic_cafe_error to your Gemfile:
 
-  gem 'kinetic_cafe_error', '~> 1.2'
+  gem 'kinetic_cafe_error', '~> 1.7'
 
 If not using Rails, install with RubyGems:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -38,8 +38,9 @@ automatically injected, which enables the following functionality:
 
 * Two rake tasks:
 
-  * <tt>rake kcerror:defined</tt>, showing the errors defined in the known
-    hierarchy.
+  * <tt>rake kcerror:defined[params]</tt>, showing the errors defined in the
+    known hierarchy. If +params+ is 'yes', the expected parameters will be
+    shown.
 
   * <tt>rake kcerror:translations[output]</tt>, creating a template translation
     file for all defined errors.

--- a/kinetic_cafe_error.gemspec
+++ b/kinetic_cafe_error.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: kinetic_cafe_error 1.6 ruby lib
+# stub: kinetic_cafe_error 1.7 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "kinetic_cafe_error"
-  s.version = "1.6"
+  s.version = "1.7"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2015-07-30"
+  s.date = "2015-08-05"
   s.description = "kinetic_cafe_error provides an API-smart error base class and a DSL for\ndefining errors. Under Rails, it also provides a controller concern\n(KineticCafe::ErrorHandler) that has a useful implementation of +rescue_from+\nto handle KineticCafe::Error types.\n\nExceptions in a hierarchy can be handled in a uniform manner, including getting\nan I18n translation message with parameters, standard status values, and\nmeaningful JSON representations that can be used to establish a standard error\nrepresentations across both clients and servers."
   s.email = ["aziegler@kineticcafe.com"]
   s.extra_rdoc_files = ["Contributing.rdoc", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Contributing.rdoc", "History.rdoc", "Licence.rdoc", "README.rdoc"]

--- a/lib/kinetic_cafe/error.rb
+++ b/lib/kinetic_cafe/error.rb
@@ -25,7 +25,7 @@ module KineticCafe # :nodoc:
   # rescue clause and handled there, as is shown in the included
   # KineticCafe::ErrorHandler controller concern for Rails.
   class Error < ::StandardError
-    VERSION = '1.6' # :nodoc:
+    VERSION = '1.7' # :nodoc:
 
     # Get the KineticCafe::Error functionality.
     include KineticCafe::ErrorModule

--- a/lib/kinetic_cafe/error.rb
+++ b/lib/kinetic_cafe/error.rb
@@ -219,4 +219,4 @@ end
 
 require_relative 'error_dsl'
 require_relative 'error_engine' if defined?(::Rails)
-require_relative 'error_tasks' if defined?(::Rake)
+require_relative 'error_tasks' if defined?(::Rake::DSL)


### PR DESCRIPTION
-   Feature: Show error parameters with `kcerror:defined`.
  -   Add a `params` parameter to the `kcerror:defined` task that will show
    the parameter names the exception expects.
-   Bug Fix: Fix RSpec Initialization under RubyMine.
  -   RubyMine does not fully initialize the project when running RSpec,
    meaning that while Rake is defined, Rake::DSL is not. As such, we need
    to prevent the Rake task from loading unless Rake::DSL is present.
