### PR TITLE
Enable error capturing and add per-error severity

### DIFF
--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,10 @@
+=== 1.8 / 2015-10-14
+
+* 1 minor enhancement:
+
+  * Add +kinetic_cafe_error_handle_post_error+ to allow for capturing or
+    post-processing of errors after logging and handling.
+
 === 1.7 / 2015-08-05
 
 * 1 minor enhancement:

--- a/README.rdoc
+++ b/README.rdoc
@@ -65,6 +65,19 @@ automatically injected, which enables the following functionality:
   that can be provided with the kinetic_cafe_error_handler_log_locale helper
   method.
 
+  The error can be then captured for processing by providing the
+  kinetic_cafe_error_handle_post_error method.
+
+  Example for capturing KineticCafe::Errors with raven-ruby for Sentry:
+
+    ExampleController < ActionController
+      include KineticCafe::ErrorHandler
+
+      def kinetic_cafe_error_handle_post_error(error)
+        Raven.capture_exception(error)
+      end
+    end
+
 === Using with Minitest
 
 KineticCafe::Error provides a number of assertions that can help testing that
@@ -110,7 +123,7 @@ KineticCafe::Error provides four experimental matchers:
 
 Add kinetic_cafe_error to your Gemfile:
 
-  gem 'kinetic_cafe_error', '~> 1.7'
+  gem 'kinetic_cafe_error', '~> 1.8'
 
 If not using Rails, install with RubyGems:
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ Hoe.plugin :email unless ENV['CI'] || ENV['TRAVIS']
 
 spec = Hoe.spec 'kinetic_cafe_error' do
   developer('Austin Ziegler', 'aziegler@kineticcafe.com')
+  developer('Jero Sutlovic', 'jsutlovic@kineticcafe.com')
 
   require_ruby_version '>= 1.9.2'
 

--- a/app/controllers/concerns/kinetic_cafe/error_handler.rb
+++ b/app/controllers/concerns/kinetic_cafe/error_handler.rb
@@ -115,14 +115,19 @@ module KineticCafe::ErrorHandler
 
   # Write the provided error to the Rails log using the value of
   # #kinetic_cafe_error_handler_log_locale. If the error has a cause, log
-  # that as well.
+  # that as well. Rails.logger.class is expected to have constants matching
+  # error.severity.upcase, which is used to determine the numeric severity
+  # to log the error at.
   def kinetic_cafe_error_log_error(error)
     locale = self.class.kinetic_cafe_error_handler_log_locale
-    Rails.logger.error(error.message(locale))
+    severity = Rails.logger.class.const_get(error.severity.upcase)
+    Rails.logger.add(severity, nil, error.message(locale))
 
     return unless error.cause
 
-    Rails.logger.error(
+    Rails.logger.add(
+      severity,
+      nil,
       t(
         'kinetic_cafe_error.cause',
         message: error.cause.message,

--- a/app/controllers/concerns/kinetic_cafe/error_handler.rb
+++ b/app/controllers/concerns/kinetic_cafe/error_handler.rb
@@ -35,11 +35,18 @@ module KineticCafe::ErrorHandler
   # This method is called with +error+ when Rails catches a KineticCafe::Error
   # descendant. It logs the message and its cause as severity error. After
   # logging as +error+, it will render to HTML or JSON. The received error is
-  # logged using the value of #kinetic_cafe_error_handler_log_locale.
+  # logged using the value of #kinetic_cafe_error_handler_log_locale. After
+  # rendering to HTML or JSON, +error+ will be passed to a post-processing
+  # handler.
   #
   # HTML is rendered with #kinetic_cafe_error_render_html. JSON is rendered
   # with #kinetic_cafe_error_render_json. Either of these can be overridden in
   # controllers for different behaviour.
+  #
+  # The +error+ is passed to #kinetic_cafe_error_handle_post_error to be
+  # handled for post-processing. This should be overridden to implement
+  # post-processing, for example passing the error to an external error
+  # capturing/tracking service such as Airbrake or Sentry.
   #
   # As an option, +kinetic_cafe_error_handler+ can also be used in a
   # +rescue_from+ block with an error class and parameters, and it will
@@ -72,6 +79,8 @@ module KineticCafe::ErrorHandler
         kinetic_cafe_error_render_json(error)
       end
     end
+
+    kinetic_cafe_error_handle_post_error(error)
   end
 
   # Render the +error+ as HTML. Uses the template +kinetic_cafe_error/page+
@@ -99,6 +108,9 @@ module KineticCafe::ErrorHandler
     else
       render error.json_result
     end
+  end
+
+  def kinetic_cafe_error_handle_post_error(_error)
   end
 
   # Write the provided error to the Rails log using the value of

--- a/kinetic_cafe_error.gemspec
+++ b/kinetic_cafe_error.gemspec
@@ -1,16 +1,16 @@
 # -*- encoding: utf-8 -*-
-# stub: kinetic_cafe_error 1.7 ruby lib
+# stub: kinetic_cafe_error 1.8 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "kinetic_cafe_error"
-  s.version = "1.7"
+  s.version = "1.8"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
-  s.authors = ["Austin Ziegler"]
-  s.date = "2015-08-05"
+  s.authors = ["Austin Ziegler", "Jero Sutlovic"]
+  s.date = "2015-10-14"
   s.description = "kinetic_cafe_error provides an API-smart error base class and a DSL for\ndefining errors. Under Rails, it also provides a controller concern\n(KineticCafe::ErrorHandler) that has a useful implementation of +rescue_from+\nto handle KineticCafe::Error types.\n\nExceptions in a hierarchy can be handled in a uniform manner, including getting\nan I18n translation message with parameters, standard status values, and\nmeaningful JSON representations that can be used to establish a standard error\nrepresentations across both clients and servers."
-  s.email = ["aziegler@kineticcafe.com"]
+  s.email = ["aziegler@kineticcafe.com", "jsutlovic@kineticcafe.com"]
   s.extra_rdoc_files = ["Contributing.rdoc", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Contributing.rdoc", "History.rdoc", "Licence.rdoc", "README.rdoc"]
   s.files = [".autotest", ".gemtest", ".rubocop.yml", ".travis.yml", "Contributing.rdoc", "Gemfile", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Rakefile", "app/controllers/concerns/kinetic_cafe/error_handler.rb", "app/views/kinetic_cafe_error/_table.html.erb", "app/views/kinetic_cafe_error/_table.html.haml", "app/views/kinetic_cafe_error/_table.html.slim", "app/views/kinetic_cafe_error/page.html.erb", "app/views/kinetic_cafe_error/page.html.haml", "app/views/kinetic_cafe_error/page.html.slim", "config/i18n-tasks.yml.erb", "config/locales/kinetic_cafe_error.en-CA.yml", "config/locales/kinetic_cafe_error.en-UK.yml", "config/locales/kinetic_cafe_error.en-US.yml", "config/locales/kinetic_cafe_error.en.yml", "config/locales/kinetic_cafe_error.fr-CA.yml", "config/locales/kinetic_cafe_error.fr.yml", "lib/kinetic_cafe/error.rb", "lib/kinetic_cafe/error/minitest.rb", "lib/kinetic_cafe/error_dsl.rb", "lib/kinetic_cafe/error_engine.rb", "lib/kinetic_cafe/error_module.rb", "lib/kinetic_cafe/error_rspec.rb", "lib/kinetic_cafe/error_tasks.rake", "lib/kinetic_cafe/error_tasks.rb", "lib/kinetic_cafe_error.rb", "test/test_helper.rb", "test/test_kinetic_cafe_error.rb", "test/test_kinetic_cafe_error_dsl.rb", "test/test_kinetic_cafe_error_hierarchy.rb"]
   s.homepage = "https://github.com/KineticCafe/kinetic_cafe_error/"
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<minitest>, ["~> 5.7"])
+      s.add_development_dependency(%q<minitest>, ["~> 5.8"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe-doofus>, ["~> 1.0"])
       s.add_development_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<coveralls>, ["~> 0.8"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
     else
-      s.add_dependency(%q<minitest>, ["~> 5.7"])
+      s.add_dependency(%q<minitest>, ["~> 5.8"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])
       s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
@@ -67,7 +67,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<hoe>, ["~> 3.13"])
     end
   else
-    s.add_dependency(%q<minitest>, ["~> 5.7"])
+    s.add_dependency(%q<minitest>, ["~> 5.8"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])
     s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])

--- a/kinetic_cafe_error.gemspec
+++ b/kinetic_cafe_error.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler", "Jero Sutlovic"]
-  s.date = "2015-10-14"
+  s.date = "2015-10-23"
   s.description = "kinetic_cafe_error provides an API-smart error base class and a DSL for\ndefining errors. Under Rails, it also provides a controller concern\n(KineticCafe::ErrorHandler) that has a useful implementation of +rescue_from+\nto handle KineticCafe::Error types.\n\nExceptions in a hierarchy can be handled in a uniform manner, including getting\nan I18n translation message with parameters, standard status values, and\nmeaningful JSON representations that can be used to establish a standard error\nrepresentations across both clients and servers."
   s.email = ["aziegler@kineticcafe.com", "jsutlovic@kineticcafe.com"]
   s.extra_rdoc_files = ["Contributing.rdoc", "History.rdoc", "Licence.rdoc", "Manifest.txt", "README.rdoc", "Contributing.rdoc", "History.rdoc", "Licence.rdoc", "README.rdoc"]
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.rdoc"]
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
-  s.rubygems_version = "2.4.8"
+  s.rubygems_version = "2.4.5"
   s.summary = "kinetic_cafe_error provides an API-smart error base class and a DSL for defining errors"
 
   if s.respond_to? :specification_version then
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rubocop>, ["~> 0.32"])
       s.add_development_dependency(%q<simplecov>, ["~> 0.7"])
       s.add_development_dependency(%q<coveralls>, ["~> 0.8"])
-      s.add_development_dependency(%q<hoe>, ["~> 3.13"])
+      s.add_development_dependency(%q<hoe>, ["~> 3.14"])
     else
       s.add_dependency(%q<minitest>, ["~> 5.8"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rubocop>, ["~> 0.32"])
       s.add_dependency(%q<simplecov>, ["~> 0.7"])
       s.add_dependency(%q<coveralls>, ["~> 0.8"])
-      s.add_dependency(%q<hoe>, ["~> 3.13"])
+      s.add_dependency(%q<hoe>, ["~> 3.14"])
     end
   else
     s.add_dependency(%q<minitest>, ["~> 5.8"])
@@ -86,6 +86,6 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rubocop>, ["~> 0.32"])
     s.add_dependency(%q<simplecov>, ["~> 0.7"])
     s.add_dependency(%q<coveralls>, ["~> 0.8"])
-    s.add_dependency(%q<hoe>, ["~> 3.13"])
+    s.add_dependency(%q<hoe>, ["~> 3.14"])
   end
 end

--- a/lib/kinetic_cafe/error.rb
+++ b/lib/kinetic_cafe/error.rb
@@ -176,6 +176,10 @@ module KineticCafe # :nodoc:
       defined?(Rack::Utils) && :bad_request || 400
     end
 
+    def default_severity
+      :error
+    end
+
     def stringify(object, namespace = nil)
       case object
       when Hash

--- a/lib/kinetic_cafe/error.rb
+++ b/lib/kinetic_cafe/error.rb
@@ -25,7 +25,7 @@ module KineticCafe # :nodoc:
   # rescue clause and handled there, as is shown in the included
   # KineticCafe::ErrorHandler controller concern for Rails.
   class Error < ::StandardError
-    VERSION = '1.7' # :nodoc:
+    VERSION = '1.8' # :nodoc:
 
     # Get the KineticCafe::Error functionality.
     include KineticCafe::ErrorModule

--- a/lib/kinetic_cafe/error_module.rb
+++ b/lib/kinetic_cafe/error_module.rb
@@ -6,6 +6,9 @@ module KineticCafe # :nodoc:
     # The HTTP status to be returned. If not provided in the constructor, uses
     # #default_status.
     attr_reader :status
+    # The severity to be returned. If not provided in the constructor, uses
+    # #default_severity
+    attr_reader :severity
     # Extra data relevant to recipients of the exception, provided on
     # construction.
     attr_reader :extra
@@ -39,6 +42,8 @@ module KineticCafe # :nodoc:
     #             value.
     # +status+::  An override to the HTTP status code to be returned by this
     #             error by default.
+    # +severity+:: An override to the default severity to be returned by this
+    #              error.
     # +i18n_params+:: The parameters to be sent to I18n.translate with the
     #                 #i18n_key.
     # +cause+:: The exception that caused this error. Used to wrap an earlier
@@ -69,6 +74,7 @@ module KineticCafe # :nodoc:
       @message && @message.freeze
 
       @status      = options.delete(:status) || default_status
+      @severity    = options.delete(:severity) || default_severity
       @i18n_params = options.delete(:i18n_params) || {}
       @extra       = options.delete(:extra)
 
@@ -147,6 +153,7 @@ module KineticCafe # :nodoc:
       {
         message:      @message,
         status:       status,
+        severity:     severity,
         name:         name,
         internal:     internal?,
         i18n_message: i18n_message,
@@ -174,9 +181,9 @@ module KineticCafe # :nodoc:
     # Nice debugging version of a KineticCafe::Error
     def inspect
       "#<#{self.class}: name=#{name} status=#{status} " \
-        "message=#{message.inspect} i18n_key=#{i18n_key} " \
-        "i18n_params=#{@i18n_params.inspect} extra=#{extra.inspect} " \
-        "cause=#{cause}>"
+        "severity=#{severity} message=#{message.inspect} " \
+        "i18n_key=#{i18n_key} i18n_params=#{@i18n_params.inspect} " \
+        "extra=#{extra.inspect} cause=#{cause}>"
     end
 
     private

--- a/test/test_kinetic_cafe_error.rb
+++ b/test/test_kinetic_cafe_error.rb
@@ -7,7 +7,7 @@ describe KineticCafe::Error do
     it 'defaults correctly' do
       stub I18n, :translate, 'Untranslatable error' do
         expected = '#<KineticCafe::Error: name=error ' \
-          "status=bad_request message=\"Untranslatable error\" " \
+          'status=bad_request severity=error message="Untranslatable error" ' \
           'i18n_key=kcerrors.error i18n_params={} extra=nil cause=>'
         assert_equal expected, exception.inspect
       end
@@ -91,6 +91,7 @@ describe KineticCafe::Error do
       assert_equal(
         {
           status: :bad_request,
+          severity: :error,
           name: 'error',
           internal: false,
           i18n_key: 'kcerrors.error'
@@ -104,6 +105,7 @@ describe KineticCafe::Error do
         {
           error: {
             status: :bad_request,
+            severity: :error,
             name: 'error',
             internal: false,
             i18n_key: 'kcerrors.error'
@@ -121,6 +123,7 @@ describe KineticCafe::Error do
           json: {
             error: {
               status: :bad_request,
+              severity: :error,
               name: 'error',
               internal: false,
               i18n_key: 'kcerrors.error'

--- a/test/test_kinetic_cafe_error_dsl.rb
+++ b/test/test_kinetic_cafe_error_dsl.rb
@@ -99,6 +99,11 @@ describe KineticCafe::ErrorDSL do
             assert_equal 400, instance.send(:default_status)
           end
         end
+
+        it 'returns :error for #default_severity (private)' do
+          refute base.private_instance_methods.include?(:default_severity)
+          assert_equal :error, instance.send(:default_severity)
+        end
       end
 
       describe 'class-based definition' do
@@ -137,6 +142,22 @@ describe KineticCafe::ErrorDSL do
               refute base.private_instance_methods.include?(:default_status)
               assert_equal 400, instance.send(:default_status)
             end
+          end
+
+          it 'returns :error for #default_severity (private)' do
+            refute base.private_instance_methods.include?(:default_severity)
+            assert_equal :error, instance.send(:default_severity)
+          end
+        end
+
+        describe 'with severity' do
+          let(:child) {
+            base.define_error class: :child, severity: :fatal
+          }
+
+          it 'returns :fatal for #default_severity (private)' do
+            refute base.private_instance_methods.include?(:default_severity)
+            assert_equal :fatal, instance.send(:default_severity)
           end
         end
 


### PR DESCRIPTION
- Add `kinetic_cafe_error_handle_post_error` which can be overridden in a controller that includes the error handler concern to capture or post-process errors (such as forwarding them to Airbrake/Sentry/NewRelic, or doing custom logging).
- Add `severity` to `KineticCafe::Error` to enable per-error severity, for logging and capturing.
