### PR TITLE
Lower default error severity level from :error to :warning

### DIFF
--- a/lib/kinetic_cafe/error_dsl.rb
+++ b/lib/kinetic_cafe/error_dsl.rb
@@ -59,7 +59,7 @@ module KineticCafe
     #              :bad_request. Must be provided if +class+ is provided. HTTP
     #              status codes are defined in Rack::Utils.
     # +severity+:: A Ruby symbol representing the severity level associated
-    #              with this error. If not provided, defaults to :error. Error
+    #              with this error. If not provided, defaults to :warn. Error
     #              severity levels are defined in Logger::Severity.
     # +key+::      The name of the error class to be created. Provide as a
     #              snake_case value that will be turned into a camelized class
@@ -141,8 +141,7 @@ module KineticCafe
       status ||= defined?(Rack::Utils) && :bad_request || 400
       status.freeze
 
-      severity ||= :error
-      severity.freeze
+      severity ||= :warn
 
       error.send :define_method, :default_status, -> { status } if status
       error.send :define_method, :default_severity, -> { severity } if severity

--- a/test/test_kinetic_cafe_error_dsl.rb
+++ b/test/test_kinetic_cafe_error_dsl.rb
@@ -101,9 +101,9 @@ describe KineticCafe::ErrorDSL do
           end
         end
 
-        it 'returns :error for #default_severity (private)' do
+        it 'returns :warn for #default_severity (private)' do
           refute base.private_instance_methods.include?(:default_severity)
-          assert_equal :error, instance.send(:default_severity)
+          assert_equal :warn, instance.send(:default_severity)
         end
 
         it 'strips non-word characters from a key' do
@@ -151,9 +151,9 @@ describe KineticCafe::ErrorDSL do
             end
           end
 
-          it 'returns :error for #default_severity (private)' do
+          it 'returns :warn for #default_severity (private)' do
             refute base.private_instance_methods.include?(:default_severity)
-            assert_equal :error, instance.send(:default_severity)
+            assert_equal :warn, instance.send(:default_severity)
           end
         end
 


### PR DESCRIPTION
Each error has a severity level (that takes one of [`:info` ,`:debug`, `:warning`, `:error`, `:fatal`] values) and the default value can be overwritten both for specific error classes and error instances.

Experience showed that the majority of defined errors are user-side errors (such as Product ID not Found) and the appropriate level for such errors would be `:warning`.

Changing the default level to :warning also means that errors for which the severity level of :error is justified need to have this declared explicitly, for example:

``` ruby
bad_request class: :sku, severity: :error
```

Which helps with code clarity and readability.

For this reasons this commit changes the default severity level to `:warning`.
